### PR TITLE
Random Component Design Disks

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -36,7 +36,7 @@
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/captain //WS Edit - Alt Uniforms
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	head = /obj/item/clothing/head/caphat
-	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1)
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/storage/box/rndboards/old=1)
 
 	backpack = /obj/item/storage/backpack/captain
 	satchel = /obj/item/storage/backpack/satchel/cap

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -86,28 +86,22 @@ other types of metals and chemistry for reagents).
 		blueprints += null
 
 /obj/item/disk/design_disk/proc/randomize()
-	// pick a techweb node at random
-	var/static/list/invalid_nodes = list(/datum/techweb_node/base)
-	var/random_node_type = pick(subtypesof(/datum/techweb_node) - invalid_nodes)
-	var/datum/techweb_node/random_node = new random_node_type
+	// iterate over all designs
+	var/list/available_designs = list()
+	for(var/path in subtypesof(/datum/design))
+		var/datum/design/DN = new path
+		// add all non-autholathe designs
+		if(DN && !(DN.build_type & AUTOLATHE))
+			available_designs += DN.id
 
-	// name the disk after the node
-	if(random_node && random_node.design_ids.len)
-		name = "Mysterious [random_node.display_name] Component Design Disk"
+	// shuffle list (randomize)
+	shuffle_inplace(available_designs)
 
-		var/number_of_designs_to_write = 0
-		// bounds check
-		if(random_node.design_ids.len < max_blueprints)
-			number_of_designs_to_write = random_node.design_ids.len
-		else
-			number_of_designs_to_write = max_blueprints
+	ASSERT(available_designs.len >= max_blueprints)
 
-		// shuffle list (randomize)
-		shuffle_inplace(random_node.design_ids)
-
-		// write designs to disk
-		for(var/i in 1 to number_of_designs_to_write)
-			blueprints[i] = random_node.design_ids[i]
+	// write designs to disk
+	for(var/i in 1 to max_blueprints)
+		blueprints[i] = available_designs[i]
 
 /obj/item/disk/design_disk/adv
 	name = "Advanced Component Design Disk"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -90,8 +90,8 @@ other types of metals and chemistry for reagents).
 	var/list/available_designs = list()
 	for(var/path in subtypesof(/datum/design))
 		var/datum/design/DN = new path
-		// add all non-autholathe designs
-		if(DN && !(DN.build_type & AUTOLATHE))
+		// add all imprinter, protolathe, and machfab designs
+		if(DN && DN.id != DESIGN_ID_IGNORE && ((DN.build_type & IMPRINTER) || (DN.build_type & PROTOLATHE) || (DN.build_type & MECHFAB)))
 			available_designs += DN.id
 
 	// shuffle list (randomize)
@@ -129,7 +129,7 @@ other types of metals and chemistry for reagents).
 	color = "#3c5c91"
 	desc = "A disk for storing device design data for construction in lathes. This one's contents could be anything."
 	custom_materials = list(/datum/material/iron =300, /datum/material/glass = 100, /datum/material/silver = 50)
-	max_blueprints = 3
+	max_blueprints = 5
 
 /obj/item/disk/design_disk/random/Initialize()
 	. = ..()

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -85,6 +85,30 @@ other types of metals and chemistry for reagents).
 	for(var/i in 1 to max_blueprints)
 		blueprints += null
 
+/obj/item/disk/design_disk/proc/randomize()
+	// pick a techweb node at random
+	var/static/list/invalid_nodes = list(/datum/techweb_node/base)
+	var/random_node_type = pick(subtypesof(/datum/techweb_node) - invalid_nodes)
+	var/datum/techweb_node/random_node = new random_node_type
+
+	// name the disk after the node
+	if(random_node && random_node.design_ids.len)
+		name = "Mysterious [random_node.display_name] Component Design Disk"
+
+		var/number_of_designs_to_write = 0
+		// bounds check
+		if(random_node.design_ids.len < max_blueprints)
+			number_of_designs_to_write = random_node.design_ids.len
+		else
+			number_of_designs_to_write = max_blueprints
+
+		// shuffle list (randomize)
+		shuffle_inplace(random_node.design_ids)
+
+		// write designs to disk
+		for(var/i in 1 to number_of_designs_to_write)
+			blueprints[i] = random_node.design_ids[i]
+
 /obj/item/disk/design_disk/adv
 	name = "Advanced Component Design Disk"
 	color = "#bed876"
@@ -105,6 +129,18 @@ other types of metals and chemistry for reagents).
 	desc = "A disk for storing device design data for construction in lathes. This one has absurd amounts of extra storage space."
 	custom_materials = list(/datum/material/iron =300, /datum/material/glass = 100, /datum/material/silver = 100, /datum/material/gold = 100, /datum/material/bluespace = 50)
 	max_blueprints = 10
+
+/obj/item/disk/design_disk/random
+	name = "Mysterious Component Design Disk"
+	color = "#3c5c91"
+	desc = "A disk for storing device design data for construction in lathes. This one's contents could be anything."
+	custom_materials = list(/datum/material/iron =300, /datum/material/glass = 100, /datum/material/silver = 50)
+	max_blueprints = 3
+
+/obj/item/disk/design_disk/random/Initialize()
+	. = ..()
+	randomize()
+
 
 //Disks with content
 /obj/item/disk/design_disk/ammo_38_hunting

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -86,13 +86,12 @@ other types of metals and chemistry for reagents).
 		blueprints += null
 
 /obj/item/disk/design_disk/proc/randomize()
-	// iterate over all designs
 	var/list/available_designs = list()
-	for(var/path in subtypesof(/datum/design))
-		var/datum/design/DN = new path
-		// add all imprinter, protolathe, and machfab designs
-		if(DN && DN.id != DESIGN_ID_IGNORE && ((DN.build_type & IMPRINTER) || (DN.build_type & PROTOLATHE) || (DN.build_type & MECHFAB)))
-			available_designs += DN.id
+	// iterate over all designs
+	for(var/design_id in SSresearch.techweb_designs)
+		var/datum/design/found_design = SSresearch.techweb_design_by_id(design_id)
+		if((found_design.build_type & IMPRINTER) || (found_design.build_type & PROTOLATHE) || (found_design.build_type & MECHFAB))
+			available_designs += found_design
 
 	// shuffle list (randomize)
 	shuffle_inplace(available_designs)


### PR DESCRIPTION
## About The Pull Request

Adds a component design disk with random contents as an item.

![image](https://user-images.githubusercontent.com/7697956/212792229-8c92f891-0d2e-407a-b896-e2417d3d9fec.png)

The disk will select 5 designs from random that are available via the imprinter, protolathe, and mechfab.

![image](https://user-images.githubusercontent.com/7697956/213044944-66a934f0-c416-4552-aa7e-6999ce22f65b.png)

Gives an RnD box to all captains when they join their ship.

![image](https://user-images.githubusercontent.com/7697956/213045998-e6b737e3-800f-45ff-8df3-7b0e76c09206.png)

- [ ] I affirm that I have tested all of my proposed changes and that any issues found during tested have been addressed.

## Why It's Good For The Game

Adds variety to R&D system

## Changelog

:cl:
add: Randomized component design disks
admin: Adds a function to give random component designs to any design disk
/:cl:
