### PR TITLE
Return of the vampires of futures past...

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -136,6 +136,7 @@
 #define NOMOUTH 23
 #define NOSOCKS 24 // You cannot wear sock
 #define NO_BONES 25 //WS Edit - Breakable Bones
+#define NOHEART 26 //Heartless vampires!
 
 //organ slots
 #define ORGAN_SLOT_BRAIN "brain"

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -24,7 +24,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Ananas Affinity","Ananas Aversion"), \
 							list("Alcohol Tolerance","Light Drinker"), \
 							list("Clown Fan","Mime Fan"), \
-							list("Bad Touch", "Friendly"))
+							list("Bad Touch", "Friendly"), \
+							list("Blood Deficiency", "Vampirism"))
 	for(var/client/client in GLOB.clients)
 		client?.prefs.check_quirk_compatibility()
 	return ..()

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -228,7 +228,7 @@
 
 /datum/quirk/vampire
 	name = "Vampirism"
-	desc = "You're a bloodsucking vampire, able to suck the blood of others, heal in coffins, transfer to them your own, and you're undead, do be careful not to run out of blood or give others too much of your own, lest peril come."
+	desc = "You're a bloodsucking vampire, able to suck the blood of others, heal in coffins, transfer to them your own, and you're undead, do be careful not to run out of blood or give others too much of your own, lest peril come. <b>This is not a license to grief.</b>"
 	value = 0
 	gain_text = "<span class='notice'>Your blood is accursed, feed on others lest you become dry and fall apart, however your blood is also helpful to others which are not vampires, and you may gift them, careful for them not to become like you.</span>"
 	lose_text = "<span class='notice'>You feel blessed, your blood no longer cursed.</span>"
@@ -255,6 +255,12 @@
 	H.dna.species.exotic_blood = /datum/reagent/blood/true_draculine
 	H.dna.species.species_traits |= species_traits
 	H.dna.species.inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
+
+/datum/quirk/vampire/post_add()
+	if(!quirk_holder.mind || quirk_holder.mind.special_role)
+		return
+	to_chat(quirk_holder, "<span class='big bold info'>Please note that your vampirism does NOT give you the right to attack people or otherwise cause any interference to \
+	the round without reason or escalation. You are not an antagonist, and the rules will treat you the same as other crewmembers.</span>")
 
 /datum/quirk/vampire/remove()
 	if(quirk_holder)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -226,3 +226,160 @@
 
 	SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_hair_day", /datum/mood_event/bald)
 
+/datum/quirk/vampire
+	name = "Vampirism"
+	desc = "You're a bloodsucking vampire, able to suck the blood of others, heal in coffins, transfer to them your own, and you're undead, do be careful not to run out of blood or give others too much of your own, lest peril come."
+	value = 0
+	gain_text = "<span class='notice'>Your blood is accursed, feed on others lest you become dry and fall apart, however your blood is also helpful to others which are not vampires, and you may gift them, careful for them not to become like you.</span>"
+	lose_text = "<span class='notice'>You feel blessed, your blood no longer cursed.</span>"
+	medical_record_text = "Patient is a vampire."
+	species_lock = TRAIT_SPECIES_BLACKLIST(SPECIES_IPC, SPECIES_JELLYPERSON, SPECIES_PLASMAMAN, SPECIES_ETHEREAL, SPECIES_VAMPIRE) //No.
+	mob_traits = list(TRAIT_NOBREATH, TRAIT_NOHUNGER)
+	var/old_blood
+	var/datum/action/vampire_quirk_drain/VA
+	var/datum/action/vampire_quirk_transfer/VD
+	var/list/old_traits
+	var/list/old_biotypes
+
+/datum/quirk/vampire/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	VA = new
+	VD = new
+	VA.Grant(H)
+	VD.Grant(H)
+	old_blood = H.dna.blood_type
+	H.dna.species.exotic_blood = /datum/reagent/blood/true_draculine
+	H.dna.species.species_traits |= list(DRINKSBLOOD)
+	H.dna.species.inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
+
+/datum/quirk/vampire/remove()
+	if(quirk_holder)
+		var/mob/living/carbon/human/H = quirk_holder
+		if(VA)
+			VA.Remove(H)
+		if(VD)
+			VD.Remove(H)
+		H.dna.species.exotic_blood = ""
+		H.dna.blood_type = old_blood
+		H.dna.species.species_traits ^= list(DRINKSBLOOD)
+		H.dna.species.inherent_biotypes = old_biotypes
+
+/datum/quirk/vampire/on_process()
+	var/mob/living/carbon/human/C = quirk_holder
+	if(istype(C.loc, /obj/structure/closet/crate/coffin))
+		C.heal_overall_damage(2,2,0, BODYPART_ORGANIC)
+		C.adjustToxLoss(-2)
+		C.adjustOxyLoss(-2)
+		C.adjustCloneLoss(-2)
+		return
+	C.blood_volume -= 0.235
+	if(C.blood_volume <= BLOOD_VOLUME_SURVIVE)
+		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
+		C.dust()
+
+#define VAMP_DRAIN_AMOUNT 50
+
+/datum/action/vampire_quirk_drain
+	name = "Drain Victim"
+	desc = "Leech blood from any compatible victim you are passively grabbing."
+	check_flags = AB_CHECK_CONSCIOUS
+	icon_icon = 'icons/effects/bleed.dmi'
+	button_icon_state = "bleed1"
+
+/datum/action/vampire_quirk_drain/Trigger()
+	. = ..()
+	if(iscarbon(owner))
+		var/mob/living/carbon/H = owner
+		if(H.quirk_cooldown["Vampire"] >= world.time)
+			to_chat(H, "<span class='warning'>You just drained blood, wait a few seconds!</span>")
+			return
+		if(H.pulling && iscarbon(H.pulling) && H.grab_state == GRAB_PASSIVE)
+			var/mob/living/carbon/victim = H.pulling
+			if(H.blood_volume >= BLOOD_VOLUME_MAXIMUM)
+				to_chat(H, "<span class='warning'>You're already full!</span>")
+				return
+			if(victim.stat == DEAD)
+				to_chat(H, "<span class='warning'>You need a living victim!</span>")
+				return
+			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits) || victim.dna.species.exotic_blood)))
+				to_chat(H, "<span class='warning'>[victim] doesn't have blood!</span>")
+				return
+			H.quirk_cooldown["Vampire"] = world.time + 30
+			if(victim.anti_magic_check(FALSE, TRUE, FALSE, 0))
+				to_chat(victim, "<span class='warning'>[H] tries to bite you, but stops before touching you!</span>")
+				to_chat(H, "<span class='warning'>[victim] is blessed! You stop just in time to avoid catching fire.</span>")
+				return
+			if(victim?.reagents?.has_reagent(/datum/reagent/consumable/garlic))
+				to_chat(victim, "<span class='warning'>[H] tries to bite you, but recoils in disgust!</span>")
+				to_chat(H, "<span class='warning'>[victim] reeks of garlic! you can't bring yourself to drain such tainted blood.</span>")
+				return
+			if(!do_after(H, 30, target = victim))
+				return
+			var/blood_volume_difference = BLOOD_VOLUME_MAXIMUM - H.blood_volume //How much capacity we have left to absorb blood
+			var/drained_blood = min(victim.blood_volume, VAMP_DRAIN_AMOUNT, blood_volume_difference)
+			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")
+			to_chat(H, "<span class='notice'>You drain some blood!</span>")
+			playsound(H, 'sound/items/drink.ogg', 30, TRUE, -2)
+			victim.blood_volume = clamp(victim.blood_volume - drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
+			H.blood_volume = clamp(H.blood_volume + drained_blood, 0, BLOOD_VOLUME_MAXIMUM)
+			if(!victim.blood_volume)
+				to_chat(H, "<span class='notice'>You finish off [victim]'s blood supply.</span>")
+
+#undef VAMP_DRAIN_AMOUNT
+
+#define VAMP_TRANSFER_AMOUNT 10
+
+/datum/action/vampire_quirk_transfer
+	name = "Blood Transfer"
+	desc = "Transfer your own tainted blood to one from which you could feed."
+	check_flags = AB_CHECK_CONSCIOUS
+	icon_icon = 'icons/effects/bleed.dmi'
+	button_icon_state = "bleed9"
+
+/datum/action/vampire_quirk_transfer/Trigger()
+	. = ..()
+	if(iscarbon(owner))
+		var/mob/living/carbon/H = owner
+		if(H.quirk_cooldown["Vampire Transfer"] >= world.time)
+			to_chat(H, "<span class='warning'>You just transfered blood, wait a few seconds!</span>")
+			return
+		if(H.pulling && iscarbon(H.pulling) && H.grab_state == GRAB_PASSIVE)
+			var/mob/living/carbon/victim = H.pulling
+			if(victim.blood_volume >= BLOOD_VOLUME_MAXIMUM)
+				to_chat(H, "<span class='warning'>They're already full!</span>")
+				return
+			if(victim.stat == DEAD)
+				to_chat(H, "<span class='warning'>You need to transfer blood to a living being!</span>")
+				return
+			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits) || victim.dna.species.exotic_blood)))
+				to_chat(H, "<span class='warning'>[victim] doesn't have blood!</span>")
+				return
+			H.quirk_cooldown["Vampire Transfer"] = world.time + 20
+			if(victim.anti_magic_check(FALSE, TRUE, FALSE, 0))
+				to_chat(victim, "<span class='warning'>[H] tries to surround twist you, but stops before touching you!</span>")
+				to_chat(H, "<span class='warning'>[victim] is blessed! You stop just in time to avoid catching fire.</span>")
+				return
+			if(victim?.reagents?.has_reagent(/datum/reagent/consumable/garlic))
+				to_chat(victim, "<span class='warning'>[H] tries to twist you, but recoils in disgust!</span>")
+				to_chat(H, "<span class='warning'>[victim] reeks of garlic! you can't bring yourself to twist such tainted blood.</span>")
+				return
+			if(!do_after(H, 20, target = victim))
+				return
+			var/blood_volume_difference = BLOOD_VOLUME_MAXIMUM - victim.blood_volume //How much capacity we have left to transfer blood
+			var/transfered_blood = min(H.blood_volume, VAMP_TRANSFER_AMOUNT, blood_volume_difference)
+			to_chat(victim, "<span class='danger'>You feel darkness leaving[H] and entering you!</span>")
+			to_chat(H, "<span class='notice'>You transfer blood to [victim]!</span>")
+			playsound(H, 'sound/items/drink.ogg', 30, TRUE, -2)
+			H.blood_volume = clamp(H.blood_volume - transfered_blood, 0, BLOOD_VOLUME_MAXIMUM)
+			var/blood_id = H.get_blood_id()
+			var/list/blood_data = H.get_blood_data(blood_id)
+			victim.reagents.add_reagent(blood_id, transfered_blood, blood_data, H.bodytemperature)
+
+#undef VAMP_TRANSFER_AMOUNT
+
+
+/mob/living/carbon/get_status_tab_items()
+	. = ..()
+	var/V = has_quirk(/datum/quirk/vampire)
+	if(V)
+		. += "<span class='notice'>Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -279,6 +279,8 @@
 		C.adjustOxyLoss(-2)
 		C.adjustCloneLoss(-2)
 		return
+	if(!C.client) //Can't blame no one for no disconnects
+		return
 	C.blood_volume -= 0.2
 	if(C.blood_volume <= BLOOD_VOLUME_BAD)
 		if(prob(5) && C.blood_volume > BLOOD_VOLUME_SURVIVE)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -255,7 +255,6 @@
 	H.dna.species.exotic_blood = /datum/reagent/blood/true_draculine
 	H.dna.species.species_traits |= species_traits
 	H.dna.species.inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
-	current_heart.qdel_self()
 
 /datum/quirk/vampire/remove()
 	if(quirk_holder)
@@ -292,7 +291,7 @@
 		C.death()
 		C.Drain()
 
-#define VAMP_DRAIN_AMOUNT 50
+#define VAMP_DRAIN_AMOUNT 20
 
 /datum/action/vampire_quirk_drain
 	name = "Drain Victim"
@@ -307,28 +306,28 @@
 		var/mob/living/carbon/H = owner
 		if(H.quirk_cooldown["Vampire"] >= world.time)
 			return
-		if(H.pulling && iscarbon(H.pulling) && H.grab_state == GRAB_PASSIVE)
+		while(H.pulling && iscarbon(H.pulling) && H.grab_state == GRAB_PASSIVE)
 			var/mob/living/carbon/victim = H.pulling
 			if(H.blood_volume >= BLOOD_VOLUME_MAXIMUM)
 				to_chat(H, "<span class='warning'>You're already full!</span>")
-				return
+				break
 			if(victim.stat == DEAD)
 				to_chat(H, "<span class='warning'>You need a living victim!</span>")
-				return
+				break
 			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits) || victim.dna.species.exotic_blood)))
 				to_chat(H, "<span class='warning'>[victim] doesn't have blood!</span>")
-				return
+				break
 			H.quirk_cooldown["Vampire"] = world.time + 30
 			if(victim.anti_magic_check(FALSE, TRUE, FALSE, 0))
 				to_chat(victim, "<span class='warning'>[H] tries to bite you, but stops before touching you!</span>")
 				to_chat(H, "<span class='warning'>[victim] is blessed! You stop just in time to avoid catching fire.</span>")
-				return
+				break
 			if(victim?.reagents?.has_reagent(/datum/reagent/consumable/garlic))
 				to_chat(victim, "<span class='warning'>[H] tries to bite you, but recoils in disgust!</span>")
 				to_chat(H, "<span class='warning'>[victim] reeks of garlic! you can't bring yourself to drain such tainted blood.</span>")
-				return
+				break
 			if(!do_after(H, 30, target = victim))
-				return
+				break
 			var/blood_volume_difference = BLOOD_VOLUME_MAXIMUM - H.blood_volume //How much capacity we have left to absorb blood
 			var/drained_blood = min(victim.blood_volume, VAMP_DRAIN_AMOUNT, blood_volume_difference)
 			to_chat(victim, "<span class='danger'>[H] is draining your blood!</span>")

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -400,6 +400,5 @@
 
 /mob/living/carbon/get_status_tab_items()
 	. = ..()
-	var/V = has_quirk(/datum/quirk/vampire)
-	if(V)
+	if(has_quirk(/datum/quirk/vampire))
 		. += "<span class='notice'>Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>"

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -241,16 +241,17 @@
 		return
 
 	var/static/list/bloodtypes_safe = list(
-		"A-" = list("A-", "O-"),
-		"A+" = list("A-", "A+", "O-", "O+"),
-		"B-" = list("B-", "O-"),
-		"B+" = list("B-", "B+", "O-", "O+"),
-		"AB-" = list("A-", "B-", "O-", "AB-"),
-		"AB+" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+"),
-		"O-" = list("O-"),
-		"O+" = list("O-", "O+"),
-		"L" = list("L"),
-		"U" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U")
+		"A-" = list("A-", "O-", "Draculine"),
+		"A+" = list("A-", "A+", "O-", "O+", "Draculine"),
+		"B-" = list("B-", "O-", "Draculine"),
+		"B+" = list("B-", "B+", "O-", "O+", "Draculine"),
+		"AB-" = list("A-", "B-", "O-", "AB-", "Draculine"),
+		"AB+" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "Draculine"),
+		"O-" = list("O-", "Draculine"),
+		"O+" = list("O-", "O+", "Draculine"),
+		"L" = list("L", "Draculine"),
+		"Draculine" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U", "Draculine"),
+		"U" = list("A-", "A+", "B-", "B+", "O-", "O+", "AB-", "AB+", "L", "U", "Draculine")
 	)
 
 	var/safe = bloodtypes_safe[bloodtype]

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -52,7 +52,7 @@
 				nutrition_ratio *= 1.25
 			adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
 			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * nutrition_ratio)
-		if(blood_volume < BLOOD_VOLUME_NORMAL && HAS_TRAIT(src, TRAIT_NOHUNGER)) //blood regen for non eaters
+		if(blood_volume < BLOOD_VOLUME_NORMAL && HAS_TRAIT(src, TRAIT_NOHUNGER) && !(NOHEART in dna.species.species_traits)) //blood regen for non eaters
 			blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * 1.25) //assumes best nutrition conditions for non eaters because they don't eat
 
 		//Effects of bloodloss

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -758,7 +758,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /mob/living/carbon/proc/needs_heart()
 	if(HAS_TRAIT(src, TRAIT_STABLEHEART))
 		return FALSE
-	if(dna && dna.species && (NOBLOOD in dna.species.species_traits)) //not all carbons have species!
+	if(dna && dna.species && (NOBLOOD in dna.species.species_traits) || (NOHEART in dna.species.species_traits)) //not all carbons have species!
 		return FALSE
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -33,6 +33,7 @@
 /datum/reagent/blood/true_draculine
 	name = "True Draculine"
 	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"="Draculine","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
+	color = "#850f2c"
 	description = "Slowly heals all damage types. Overdose will, after a short while, turn you into a vampire, addiction lowers your max health as your body attempts to fight off the corruption, if you're incompatible you're immune to the addiction and overdose will damage you instead."
 	metabolization_rate = 1
 	addiction_threshold = 20

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -25,12 +25,98 @@
 
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		if(C.get_blood_id() == /datum/reagent/blood && (method == INJECT || (method == INGEST && C.dna && C.dna.species && (DRINKSBLOOD in C.dna.species.species_traits))))
-			if(!data || !(data["blood_type"] in get_safe_blood(C.dna.blood_type)))
+		if(C.get_blood_id() == /datum/reagent/blood || C.get_blood_id() == /datum/reagent/blood/true_draculine && (method == INJECT || (method == INGEST && C.dna && C.dna.species && (DRINKSBLOOD in C.dna.species.species_traits))))
+			if((!data || !(data["blood_type"] in get_safe_blood(C.dna.blood_type))) && C.get_blood_id() != /datum/reagent/blood/true_draculine)
 				C.reagents.add_reagent(/datum/reagent/toxin, reac_volume * 0.5)
 			else
 				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
+/datum/reagent/blood/true_draculine
+	name = "True Draculine"
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"="Draculine","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
+	description = "Slowly heals all damage types. Overdose will, after a short while, turn you into a vampire, addiction lowers your max health as your body attempts to fight off the corruption, if you're incompatible you're immune to the addiction and overdose will damage you instead."
+	metabolization_rate = 1
+	addiction_threshold = 20
+	overdose_threshold = 30
+	var/healing = 0.20
 
+/datum/reagent/blood/true_draculine/on_mob_add(mob/living/carbon/human/M)
+	if(M.dna.species.exotic_blood)
+		src.addiction_threshold = 0
+	if(M.dna.species.exotic_blood == /datum/reagent/blood/true_draculine)
+		src.overdose_threshold = 0
+	..()
+
+/datum/reagent/blood/true_draculine/on_mob_life(mob/living/carbon/human/M)
+	if(M.dna.species.exotic_blood != /datum/reagent/blood/true_draculine)
+		M.adjustToxLoss(-healing*REM, 0, TRUE)
+		M.adjustOxyLoss(-healing*REM, 0)
+		M.adjustBruteLoss(-healing*REM, 0)
+		M.adjustFireLoss(-healing*REM, 0)
+		M.Jitter(2)
+		. = 1
+	..()
+
+/datum/reagent/blood/true_draculine/overdose_process(mob/living/carbon/human/M)
+	if(M.dna.species.exotic_blood)
+		M.adjustToxLoss(1*REM, 0)
+		M.adjustOxyLoss(1*REM, 0)
+		M.adjustBruteLoss(1*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(1*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.Jitter(6)
+	else
+		if(current_cycle >= 50)
+			for(var/datum/reagent/addiction in M.reagents.addiction_list)
+				if(addiction.name == "True Draculine")
+					M.reagents.remove_addiction(addiction)
+			M.add_quirk(/datum/quirk/vampire)
+	..()
+	. = 1
+
+/datum/reagent/blood/true_draculine/addiction_act_stage1(mob/living/carbon/human/M)
+	M.dna.species.species_traits |= list(DRINKSBLOOD)
+	if(M.health > 60)
+		M.adjustToxLoss(1.5*REM, 0)
+		M.adjustOxyLoss(1.5*REM, 0)
+		M.adjustBruteLoss(1.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(1.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		. = 1
+	M.Jitter(3)
+	..()
+
+/datum/reagent/blood/true_draculine/addiction_act_stage2(mob/living/M)
+	if(M.health > 50)
+		M.adjustToxLoss(2.5*REM, 0)
+		M.adjustOxyLoss(2.5*REM, 0)
+		M.adjustBruteLoss(2.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(2.5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		. = 1
+	M.Jitter(4)
+	..()
+
+/datum/reagent/blood/true_draculine/addiction_act_stage3(mob/living/M)
+	if(M.health > 40)
+		M.adjustToxLoss(3*REM, 0)
+		M.adjustOxyLoss(3*REM, 0)
+		M.adjustBruteLoss(3*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(3*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		. = 1
+	M.Jitter(5)
+	..()
+
+/datum/reagent/blood/true_draculine/addiction_act_stage4(mob/living/M)
+	if(M.health > 30)
+		M.adjustToxLoss(5*REM, 0)
+		M.adjustOxyLoss(5*REM, 0)
+		M.adjustBruteLoss(5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		M.adjustFireLoss(5*REM, FALSE, FALSE, BODYPART_ORGANIC)
+		. = 1
+	M.Jitter(6)
+	..()
+
+/datum/reagent/blood/true_draculine/on_addiction_removal(mob/living/carbon/human/M)
+	if(!(/datum/quirk/vampire in M.roundstart_quirks))
+		M.dna.species.species_traits ^= list(DRINKSBLOOD)
+	..()
 
 /datum/reagent/blood/on_new(list/data)
 	if(istype(data))

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -124,7 +124,7 @@
 	if(world.time > (last_pump + pump_delay))
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
-			if(H.dna && (!(NOBLOOD in H.dna.species.species_traits) || ((NOHEART in H.dna.species.species_traits) && H.blood_volume >= BLOOD_VOLUME_SURVIVE)))
+			if(H.dna && (!(NOBLOOD in H.dna.species.species_traits) || ((NOHEART in H.dna.species.species_traits) && H.blood_volume > BLOOD_VOLUME_BAD)))
 				H.blood_volume = max(H.blood_volume - blood_loss, 0)
 				to_chat(H, "<span class='userdanger'>You have to keep pumping your blood!</span>")
 				if(add_colour)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -124,7 +124,7 @@
 	if(world.time > (last_pump + pump_delay))
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
-			if(H.dna && !(NOBLOOD in H.dna.species.species_traits))
+			if(H.dna && (!(NOBLOOD in H.dna.species.species_traits) || ((NOHEART in H.dna.species.species_traits) && H.blood_volume >= BLOOD_VOLUME_SURVIVE)))
 				H.blood_volume = max(H.blood_volume - blood_loss, 0)
 				to_chat(H, "<span class='userdanger'>You have to keep pumping your blood!</span>")
 				if(add_colour)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds the vampire quirk in it's unupdated but functional state, alongside the Draculine bloodtype. If there's any issue I missed feel free to SCREAM at me :blush:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The vampire species is rather buggy like the other unmaintaned species and it's hard to use vampires as-is, this also reducing the need for admins to deal with the vampire species change problems (loss of quirks, baldness, loss of hair color). As of course there are characters that are vampires, and it's cool.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Why Echo, not Shiptest?
The vampire quirk will take a while to be fully remade, and it's messy to have it testmerged and constantly rebalanced on main as it was, especially with the neutral quirk value, still I understand if this PR gets closed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added the Vampire quirk and the Draculine bloodtype.
code: Added the NOHEART species trait for specific applications where one should still bleed and survive without a heart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
